### PR TITLE
Add OpenGL ES 2.0 renderer (also fix a build error)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16.3)
 
 option(STDMEM "Use standard libc memory allocators instead of the fast custom one" OFF)
+option(GLES "Use OpenGL ES 2.0 instead of OpenGL Core 3.2" OFF)
 
 project(funkin LANGUAGES C)
 
@@ -37,8 +38,6 @@ add_executable(funkin WIN32 # The `WIN32` here is so we don't get a command prom
 	"src/pad.h"
 	"src/pc/timer.c"
 	"src/timer.h"
-	"src/pc/glad/glad.c"
-	"src/pc/glad/glad.h"
 	"src/stage/dummy.c"
 	"src/stage/dummy.h"
 	"src/stage/week1.c"
@@ -84,6 +83,18 @@ add_executable(funkin WIN32 # The `WIN32` here is so we don't get a command prom
 	"src/object/combo.c"
 	"src/object/combo.h"
 )
+
+if (GLES)
+	target_compile_definitions(funkin PRIVATE PSXF_GLES)
+
+#	find_package(GLESv2 REQUIRED)
+	target_link_libraries(funkin PRIVATE GLESv2)
+else()
+	target_sources(funkin PRIVATE
+		"src/pc/glad/glad.c"
+		"src/pc/glad/glad.h"
+	)
+endif()
 
 # Make it so the code knows it's targetting PC
 target_compile_definitions(funkin PRIVATE PSXF_PC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,8 @@ else()
 		"src/pc/glad/glad.c"
 		"src/pc/glad/glad.h"
 	)
+
+	target_link_libraries(funkin PRIVATE ${CMAKE_DL_LIBS})
 endif()
 
 # Make it so the code knows it's targetting PC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,12 @@ add_executable(funkin WIN32 # The `WIN32` here is so we don't get a command prom
 if (GLES)
 	target_compile_definitions(funkin PRIVATE PSXF_GLES)
 
-#	find_package(GLESv2 REQUIRED)
 	target_link_libraries(funkin PRIVATE GLESv2)
+	# Raspberry Pi Broadcom GLESv2 driver.
+	# Would be nice to test someday, but it doesn't work during X sessions,
+	# and this port cannot be ran from the terminal (yet).
+	# For now, we'll just have to settle with the open-source Mesa driver.
+	#target_link_libraries(funkin PRIVATE m "/opt/vc/lib/libbrcmGLESv2.so")
 else()
 	target_sources(funkin PRIVATE
 		"src/pc/glad/glad.c"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,10 @@ add_executable(funkin WIN32 # The `WIN32` here is so we don't get a command prom
 )
 
 if (GLES)
+	# Enable OpenGL ES 2.0 code
 	target_compile_definitions(funkin PRIVATE PSXF_GLES)
 
+	# Link OpenGL ES 2.0 library
 	target_link_libraries(funkin PRIVATE GLESv2)
 	# Raspberry Pi Broadcom GLESv2 driver.
 	# Would be nice to test someday, but it doesn't work during X sessions,
@@ -94,11 +96,13 @@ if (GLES)
 	# For now, we'll just have to settle with the open-source Mesa driver.
 	#target_link_libraries(funkin PRIVATE m "/opt/vc/lib/libbrcmGLESv2.so")
 else()
+	# Include the 'glad' OpenGL loader
 	target_sources(funkin PRIVATE
 		"src/pc/glad/glad.c"
 		"src/pc/glad/glad.h"
 	)
 
+	# glad requires libdl on Unix platforms
 	target_link_libraries(funkin PRIVATE ${CMAKE_DL_LIBS})
 endif()
 

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -447,7 +447,9 @@ void Gfx_Flip(void)
 	if (clear_e)
 	{
 		glClearColor(clear_r, clear_g, clear_b, 1.0f);
-	#ifndef PSXF_GLES
+	#ifdef PSXF_GLES
+		glClearDepthf(1.0f);
+	#else
 		glClearDepth(1.0f);
 	#endif
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -202,7 +202,7 @@ GLuint Gfx_CreateTexture(GLint width, GLint height)
 	//Set texture parameters
 	glBindTexture(GL_TEXTURE_2D, texture_id);
 #ifdef PSXF_GLES
-	// OpenGL ES 2.0 does not support RGBA5551, so settle for RGBA8888 instead.
+	//OpenGL ES 2.0 does not support RGBA5551, so settle for RGBA8888 instead.
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 #else
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB5_A1, width, height, 0, GL_RGBA, GL_UNSIGNED_SHORT_1_5_5_5_REV, NULL);
@@ -221,7 +221,7 @@ void Gfx_UploadTexture(GLuint texture_id, const u8 *data, GLint width, GLint hei
 	//Upload data to texture
 	glBindTexture(GL_TEXTURE_2D, texture_id);
 #ifdef PSXF_GLES
-	// OpenGL ES 2.0 does not support RGBA5551, so settle for RGBA8888 instead.
+	//OpenGL ES 2.0 does not support RGBA5551, so settle for RGBA8888 instead.
 	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, (const void*)data);
 #else
 	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_SHORT_1_5_5_5_REV, (const void*)data);
@@ -526,14 +526,15 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 			
 			//Convert palette
 		#ifdef PSXF_GLES
-			u8 tex_palette[16][4];
+			u8 tex_palette[16][4]; //RGBA8888
 		#else
-			u8 tex_palette[16][2];
+			u8 tex_palette[16][2]; //RGBA5551
 		#endif
 			
 			u8 *tex_palette_p = &tex_palette[0][0];
 			const u8 *tim_clut_data_p = tim_clut_data;
 		#ifdef PSXF_GLES
+			//Convert palette to RGBA8888
 			for (u16 i = 0; i < tim_clut_w; i++, tex_palette_p += 4, tim_clut_data_p += 2)
 			{
 				u16 raw_pal = tim_clut_data_p[0] | (tim_clut_data_p[1] << 8);
@@ -560,6 +561,7 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 				}
 			}
 		#else
+			//Copy the RGBA5551 palette as-is, and correct its alpha bit
 			for (u16 i = 0; i < tim_clut_w; i++, tex_palette_p += 2, tim_clut_data_p += 2)
 			{
 				tex_palette_p[0] = tim_clut_data_p[0];
@@ -583,14 +585,15 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 			
 			//Convert art
 		#ifdef PSXF_GLES
-			u8 tex_data[256*256][4];
+			u8 tex_data[256*256][4]; //RGBA8888
 		#else
-			u8 tex_data[256*256][2];
+			u8 tex_data[256*256][2]; //RGBA5551
 		#endif
 			
 			u8 *tex_data_p = &tex_data[0][0];
 			const u8 *tim_tex_data_p = tim_tex_data;
 		#ifdef PSXF_GLES
+			//Output RGBA8888 bitmap
 			for (size_t i = (tim_tex_w << 1) * tim_tex_h; i > 0; i--, tex_data_p += 8, tim_tex_data_p++)
 			{
 				u8 *mapp;
@@ -606,6 +609,7 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 				tex_data_p[7] = mapp[3];
 			}
 		#else
+			//Output RGBA5551 bitmap
 			for (size_t i = (tim_tex_w << 1) * tim_tex_h; i > 0; i--, tex_data_p += 4, tim_tex_data_p++)
 			{
 				u8 *mapp;
@@ -633,14 +637,15 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 			
 			//Convert palette
 		#ifdef PSXF_GLES
-			u8 tex_palette[256][4];
+			u8 tex_palette[256][4]; //RGBA8888
 		#else
-			u8 tex_palette[256][2];
+			u8 tex_palette[256][2]; //RGBA5551
 		#endif
 			
 			u8 *tex_palette_p = &tex_palette[0][0];
 			const u8 *tim_clut_data_p = tim_clut_data;
 		#ifdef PSXF_GLES
+			//Convert palette to RGBA8888
 			for (u16 i = 0; i < tim_clut_w; i++, tex_palette_p += 4, tim_clut_data_p += 2)
 			{
 				u16 raw_pal = tim_clut_data_p[0] | (tim_clut_data_p[1] << 8);
@@ -667,6 +672,7 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 				}
 			}
 		#else
+			//Copy the RGBA5551 palette as-is, and correct its alpha bit
 			for (u16 i = 0; i < tim_clut_w; i++, tex_palette_p += 2, tim_clut_data_p += 2)
 			{
 				tex_palette_p[0] = tim_clut_data_p[0];
@@ -690,14 +696,15 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 			
 			//Convert art
 		#ifdef PSXF_GLES
-			u8 tex_data[256*256][4];
+			u8 tex_data[256*256][4]; //RGBA8888
 		#else
-			u8 tex_data[256*256][2];
+			u8 tex_data[256*256][2]; //RGBA5551
 		#endif
 			
 			u8 *tex_data_p = &tex_data[0][0];
 			const u8 *tim_tex_data_p = tim_tex_data;
 		#ifdef PSXF_GLES
+			//Output RGBA8888 bitmap
 			for (size_t i = (tim_tex_w << 1) * tim_tex_h; i > 0; i--, tex_data_p += 4, tim_tex_data_p++)
 			{
 				u8 *mapp = &tex_palette[*tim_tex_data_p][0];
@@ -707,6 +714,7 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 				tex_data_p[3] = mapp[3];
 			}
 		#else
+			//Output RGBA5551 bitmap
 			for (size_t i = (tim_tex_w << 1) * tim_tex_h; i > 0; i--, tex_data_p += 2, tim_tex_data_p++)
 			{
 				u8 *mapp = &tex_palette[*tim_tex_data_p][0];


### PR DESCRIPTION
With this, the port runs at full speed on my Raspberry Pi 3B+. Unfortunately, I was only able to test it with the open-source Mesa driver, as the closed-source Broadcom driver does not work in an X session, and this port is unable to run from the terminal. If this port had an SDL2 backend, then it would gain support for running from the terminal for free - it's just something GLFW3 lacks.

I also fixed a build error involving libdl not being linked. Recent versions of glibc merged libdl with libc, removing the need to link it separately, which is why I never encountered this error on Arch Linux. The old version of Raspberry Pi OS I'm currently using lacks this change, allowing the error to manifest.

Your fragment shader also appeared to contain a bug: it compared a float to an integer, which caused the GLSL ES 1.0 compiler to produce an error. I don't know if this is valid GLSL Core 1.50, but I've fixed it in both GLSL versions regardless.