### PR TITLE
Cleanup, fix build error, make window resizeable, make renderer use a single texture atlas

### DIFF
--- a/src/gfx.h
+++ b/src/gfx.h
@@ -32,7 +32,8 @@
 typedef struct
 {
 #ifdef PSXF_PC
-	u16 tpage;
+	u16 tpage_x;
+	u16 tpage_y;
 #else
 	u32 tim_mode;
 	RECT tim_prect, tim_crect;

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -4,6 +4,14 @@
 #include "psx.h"
 #include "io.h"
 
+#ifdef PSXF_PC
+ #ifdef PSXF_GLES
+  #include <GLES2/gl2.h>
+ #else
+  #include "glad/glad.h"
+ #endif
+#endif
+
 //Gfx constants
 #define SCREEN_WIDTH   320
 #define SCREEN_HEIGHT  240
@@ -23,10 +31,14 @@
 //Gfx structures
 typedef struct
 {
+#ifdef PSXF_PC
+	u16 tpage;
+#else
 	u32 tim_mode;
 	RECT tim_prect, tim_crect;
 	u16 tpage, clut;
 	u8 pxshift;
+#endif
 } Gfx_Tex;
 
 //Gfx functions

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -4,14 +4,6 @@
 #include "psx.h"
 #include "io.h"
 
-#ifdef PSXF_PC
- #ifdef PSXF_GLES
-  #include <GLES2/gl2.h>
- #else
-  #include "glad/glad.h"
- #endif
-#endif
-
 //Gfx constants
 #define SCREEN_WIDTH   320
 #define SCREEN_HEIGHT  240

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,7 @@ GameLoop gameloop;
 //Error handler
 char error_msg[0x200];
 
-void ErrorLock()
+void ErrorLock(void)
 {
 	while (1)
 	{

--- a/src/mem.c
+++ b/src/mem.c
@@ -4,6 +4,7 @@
 
 #include "main.h"
 #include "gfx.h"
+#include "psx.h"
 #include "random.h"
 
 typedef struct
@@ -116,7 +117,7 @@ void *Mem_Alloc(size_t size)
 		mem_max = mem_used;
 	
 	#ifdef MEM_LEAK_CHECK
-		for (int i = 0; i < 256; i++)
+		for (int i = 0; i < COUNT_OF(signs); i++)
 		{
 			if (signs[i] == NULL)
 			{
@@ -167,7 +168,7 @@ void Mem_Free(void *ptr)
 			*max = mem_max;
 		
 		#ifdef MEM_LEAK_CHECK
-			for (int i = 0; i < 256; i++)
+			for (int i = 0; i < COUNT_OF(signs); i++)
 				if (signs[i] != NULL)
 					FntPrint("%s\n", signs[i]);
 		#endif

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -122,7 +122,7 @@ static GLuint generic_shader_id;
 #define TPAGE_Y 2
 
 static GLuint plain_texture;
-static GLuint tpage_texture[TPAGE_Y * TPAGE_X];
+static GLuint tpage_texture[TPAGE_Y][TPAGE_X];
 
 //Batch
 #ifndef PSXF_GLES
@@ -432,8 +432,9 @@ void Gfx_Init(void)
 #endif
 	Gfx_UploadTexture(plain_texture = Gfx_CreateTexture(1, 1), plain_texture_data, 1, 1);
 	
-	for (size_t i = 0; i < (TPAGE_X * TPAGE_Y); i++)
-		tpage_texture[i] = Gfx_CreateTexture(256, 256);
+	for (size_t y = 0; y < TPAGE_Y; y++)
+		for (size_t x = 0; x < TPAGE_X; x++)
+			tpage_texture[y][x] = Gfx_CreateTexture(256, 256);
 	
 	//Create batch VAO
 #ifndef PSXF_GLES
@@ -604,7 +605,8 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 			u16 tim_tex_h = tim_tex[10] | (tim_tex[11] << 8);
 			u8 *tim_tex_data = &tim_tex[12];
 			
-			tex->tpage = ((tim_tex_y >> 8) % TPAGE_Y) * TPAGE_X + ((tim_tex_x >> 6) % TPAGE_X);
+			tex->tpage_x = (tim_tex_x >> 6) % TPAGE_X;
+			tex->tpage_y = (tim_tex_y >> 8) % TPAGE_Y;
 			
 			//Convert art
 		#ifdef PSXF_GLES
@@ -646,7 +648,7 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 		#endif
 			
 			//Upload to texture
-			Gfx_UploadTexture(tpage_texture[tex->tpage], &tex_data[0][0], tim_tex_w << 2, tim_tex_h);
+			Gfx_UploadTexture(tpage_texture[tex->tpage_y][tex->tpage_x], &tex_data[0][0], tim_tex_w << 2, tim_tex_h);
 			break;
 		}
 		case 1: //8bpp
@@ -715,7 +717,8 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 			u16 tim_tex_h = tim_tex[10] | (tim_tex[11] << 8);
 			u8 *tim_tex_data = &tim_tex[12];
 			
-			tex->tpage = ((tim_tex_y >> 8) % TPAGE_Y) * TPAGE_X + ((tim_tex_x >> 6) % TPAGE_X);
+			tex->tpage_x = (tim_tex_x >> 6) % TPAGE_X;
+			tex->tpage_y = (tim_tex_y >> 8) % TPAGE_Y;
 			
 			//Convert art
 		#ifdef PSXF_GLES
@@ -747,7 +750,7 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 		#endif
 			
 			//Upload to texture
-			Gfx_UploadTexture(tpage_texture[tex->tpage], &tex_data[0][0], tim_tex_w << 1, tim_tex_h);
+			Gfx_UploadTexture(tpage_texture[tex->tpage_y][tex->tpage_x], &tex_data[0][0], tim_tex_w << 1, tim_tex_h);
 			break;
 		}
 		case 2: //16bpp
@@ -800,7 +803,7 @@ void Gfx_BlitTexCol(Gfx_Tex *tex, const RECT *src, s32 x, s32 y, u8 r, u8 g, u8 
 	cmd.g = (float)g / 128.0f;
 	cmd.b = (float)b / 128.0f;
 	cmd.a = 1.0f;
-	cmd.texture_id = tpage_texture[tex->tpage];
+	cmd.texture_id = tpage_texture[tex->tpage_y][tex->tpage_x];
 	
 	//Push command
 	*dlist_p++ = cmd;
@@ -827,7 +830,7 @@ void Gfx_DrawTexCol(Gfx_Tex *tex, const RECT *src, const RECT *dst, u8 r, u8 g, 
 	cmd.g = (float)g / 128.0f;
 	cmd.b = (float)b / 128.0f;
 	cmd.a = 1.0f;
-	cmd.texture_id = tpage_texture[tex->tpage];
+	cmd.texture_id = tpage_texture[tex->tpage_y][tex->tpage_x];
 	
 	//Push command
 	*dlist_p++ = cmd;

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -152,7 +152,7 @@ static void Gfx_FramebufferSizeCallback(GLFWwindow *window, int fb_width, int fb
 	glViewport((fb_width - viewport_width) / 2, (fb_height - viewport_height) / 2, viewport_width, viewport_height);
 }
 
-GLuint Gfx_CompileShader(const char *src_vert, const char *src_frag)
+static GLuint Gfx_CompileShader(const char *src_vert, const char *src_frag)
 {
 	//Create shader
 	GLint shader_status;
@@ -211,7 +211,7 @@ GLuint Gfx_CompileShader(const char *src_vert, const char *src_frag)
 	return shader_id;
 }
 
-GLuint Gfx_CreateTexture(GLint width, GLint height)
+static GLuint Gfx_CreateTexture(GLint width, GLint height)
 {
 	//Create texture object
 	GLuint texture_id;
@@ -234,7 +234,7 @@ GLuint Gfx_CreateTexture(GLint width, GLint height)
 	return texture_id;
 }
 
-void Gfx_UploadTexture(GLuint texture_id, const u8 *data, GLint width, GLint height)
+static void Gfx_UploadTexture(GLuint texture_id, const u8 *data, GLint width, GLint height)
 {
 	//Upload data to texture
 	glBindTexture(GL_TEXTURE_2D, texture_id);
@@ -246,7 +246,7 @@ void Gfx_UploadTexture(GLuint texture_id, const u8 *data, GLint width, GLint hei
 #endif
 }
 
-void Gfx_PushBatch()
+static void Gfx_PushBatch()
 {
 	//Drop if we haven't batched any data
 	if (batch_buffer_p == &batch_buffer[0][0])
@@ -271,7 +271,7 @@ void Gfx_PushBatch()
 	glDrawArrays(GL_TRIANGLES, 0, batch_buffer_p - &batch_buffer[0][0]);
 }
 
-void Gfx_DisplayCmd(const Gfx_Cmd *cmd)
+static void Gfx_DisplayCmd(const Gfx_Cmd *cmd)
 {
 	//Push batch and bind if new texture
 	if (cmd->texture_id != batch_texture_id)

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -134,6 +134,24 @@ static Gfx_Vertex batch_buffer[COUNT_OF(dlist)][6]; //TODO: index buffer
 static Gfx_Vertex *batch_buffer_p;
 
 //Internal gfx functions
+static void Gfx_FramebufferSizeCallback(GLFWwindow *window, int fb_width, int fb_height)
+{
+	// Center the viewport within the window while maintaining the aspect ratio
+	GLfloat viewport_width, viewport_height;
+	if ((float)fb_width / (float)fb_height > (float)SCREEN_WIDTH / (float)SCREEN_HEIGHT)
+	{
+		viewport_width = fb_height * SCREEN_WIDTH / SCREEN_HEIGHT;
+		viewport_height = fb_height;
+	}
+	else
+	{
+		viewport_width = fb_width;
+		viewport_height = fb_width * SCREEN_HEIGHT / SCREEN_WIDTH;
+	}
+
+	glViewport((fb_width - viewport_width) / 2, (fb_height - viewport_height) / 2, viewport_width, viewport_height);
+}
+
 GLuint Gfx_CompileShader(const char *src_vert, const char *src_frag)
 {
 	//Create shader
@@ -362,6 +380,9 @@ void Gfx_Init(void)
 		glfwSetWindowPos(window, (mode->width - WINDOW_WIDTH) / 2, (mode->height - WINDOW_HEIGHT) / 2);
 	glfwShowWindow(window);
 	
+	//Define callback for window resizing
+	glfwSetFramebufferSizeCallback(window, Gfx_FramebufferSizeCallback);
+	
 	//Enable vsync
 	if (glfwExtensionSupported("GLX_EXT_swap_control_tear") || glfwExtensionSupported("WGL_EXT_swap_control_tear"))
 		glfwSwapInterval(-1);
@@ -474,25 +495,6 @@ void Gfx_Flip(void)
 	glfwPollEvents();
 	if (glfwWindowShouldClose(window))
 		exit(0);
-	
-	//Update the viewport in case the window has been resized
-	int fb_width, fb_height;
-	glfwGetFramebufferSize(window, &fb_width, &fb_height);
-
-	// Center the viewport within the window while maintaining the aspect ratio
-	GLfloat viewport_width, viewport_height;
-	if ((float)fb_width / (float)fb_height > (float)SCREEN_WIDTH / (float)SCREEN_HEIGHT)
-	{
-		viewport_width = fb_height * SCREEN_WIDTH / SCREEN_HEIGHT;
-		viewport_height = fb_height;
-	}
-	else
-	{
-		viewport_width = fb_width;
-		viewport_height = fb_width * SCREEN_HEIGHT / SCREEN_WIDTH;
-	}
-
-	glViewport((fb_width - viewport_width) / 2, (fb_height - viewport_height) / 2, viewport_width, viewport_height);
 	
 	//Initialize frame
 	dlist_p = dlist;

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -762,13 +762,13 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 		case 2: //16bpp
 		{
 			sprintf(error_msg, "[Gfx_LoadTex] 16bpp unsupported");
-			ErrorLock(); //Doesn't actuall return
+			ErrorLock(); //Doesn't actually return
 			break;
 		}
 		case 3: //24bpp
 		{
 			sprintf(error_msg, "[Gfx_LoadTex] 24bpp unsupported");
-			ErrorLock(); //Doesn't actuall return
+			ErrorLock(); //Doesn't actually return
 			break;
 		}
 	}

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -403,9 +403,8 @@ void Gfx_Init(void)
 	static const u8 plain_texture_data[] = {0xFF, 0xFF, 0xFF, 0xFF};
 	Gfx_UploadTexture(plain_texture = Gfx_CreateTexture(1, 1), plain_texture_data, 1, 1);
 	
-	GLuint *tpage_texture_p = tpage_texture;
-	for (size_t i = 0; i < (TPAGE_X * TPAGE_Y); i++, tpage_texture_p++)
-		*tpage_texture_p = Gfx_CreateTexture(256, 256);
+	for (size_t i = 0; i < (TPAGE_X * TPAGE_Y); i++)
+		tpage_texture[i] = Gfx_CreateTexture(256, 256);
 	
 	//Create batch VAO
 #ifndef PSXF_GLES

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -246,7 +246,7 @@ static void Gfx_UploadTexture(GLuint texture_id, const u8 *data, GLint width, GL
 #endif
 }
 
-static void Gfx_PushBatch()
+static void Gfx_PushBatch(void)
 {
 	//Drop if we haven't batched any data
 	if (batch_buffer_p == &batch_buffer[0][0])

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -421,7 +421,7 @@ void Gfx_Init(void)
 	glUniformMatrix4fv(glGetUniformLocation(generic_shader_id, "u_projection"), 1, GL_FALSE, &projection[0][0]);
 	
 	//Create textures
-	static const u8 plain_texture_data[] = {0xFF, 0xFF, 0xFF, 0xFF};
+	static const u8 plain_texture_data[] = {0xFF, 0xFF};
 	Gfx_UploadTexture(plain_texture = Gfx_CreateTexture(1, 1), plain_texture_data, 1, 1);
 	
 	for (size_t i = 0; i < (TPAGE_X * TPAGE_Y); i++)

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -125,7 +125,9 @@ static GLuint plain_texture;
 static GLuint tpage_texture[TPAGE_Y * TPAGE_X];
 
 //Batch
+#ifndef PSXF_GLES
 static GLuint batch_vao;
+#endif
 static GLuint batch_vbo;
 
 static GLuint batch_texture_id;
@@ -229,7 +231,9 @@ static GLuint Gfx_CreateTexture(GLint width, GLint height)
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+#ifndef PSXF_GLES
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+#endif
 	
 	return texture_id;
 }

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -425,7 +425,11 @@ void Gfx_Init(void)
 	glUniformMatrix4fv(glGetUniformLocation(generic_shader_id, "u_projection"), 1, GL_FALSE, &projection[0][0]);
 	
 	//Create textures
-	static const u8 plain_texture_data[] = {0xFF, 0xFF};
+#ifdef PSXF_GLES
+	static const u8 plain_texture_data[] = {0xFF, 0xFF, 0xFF, 0xFF}; //RGBA8888
+#else
+	static const u8 plain_texture_data[] = {0xFF, 0xFF}; //RGBA5551
+#endif
 	Gfx_UploadTexture(plain_texture = Gfx_CreateTexture(1, 1), plain_texture_data, 1, 1);
 	
 	for (size_t i = 0; i < (TPAGE_X * TPAGE_Y); i++)

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -25,7 +25,7 @@ GLFWwindow *window;
 //Render state
 static mat4 projection;
 
-static float clear_r, clear_g, clear_b;
+static u8 clear_r, clear_g, clear_b;
 static boolean clear_e;
 
 //Display list
@@ -410,9 +410,9 @@ void Gfx_Init(void)
 	//Initialize render state
 	glm_ortho(0.0f, (float)SCREEN_WIDTH, (float)SCREEN_HEIGHT, 0.0f, -1.0f, 1.0f, projection);
 	
-	clear_r = 0.0f;
-	clear_g = 0.0f;
-	clear_b = 0.0f;
+	clear_r = 0;
+	clear_g = 0;
+	clear_b = 0;
 	clear_e = true;
 	
 	//Initialize OpenGL state
@@ -472,13 +472,22 @@ void Gfx_Flip(void)
 	//Clear screen
 	if (clear_e)
 	{
-		glClearColor(clear_r, clear_g, clear_b, 1.0f);
+		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 	#ifdef PSXF_GLES
 		glClearDepthf(1.0f);
 	#else
 		glClearDepth(1.0f);
 	#endif
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+		//Draw the background color (we don't do this with glClearColor
+		//or else we'd end up drawing in the black bars around the screen)
+		RECT rect;
+		rect.x = 0;
+		rect.y = 0;
+		rect.w = SCREEN_WIDTH;
+		rect.h = SCREEN_HEIGHT;
+		Gfx_DrawRect(&rect, clear_r, clear_g, clear_b);
 	}
 	
 	//Traverse display list
@@ -511,9 +520,9 @@ void Gfx_Flip(void)
 void Gfx_SetClear(u8 r, u8 g, u8 b)
 {
 	//Update clear colour
-	clear_r = (float)r / 255.0f;
-	clear_g = (float)g / 255.0f;
-	clear_b = (float)b / 255.0f;
+	clear_r = r;
+	clear_g = g;
+	clear_b = b;
 }
 
 void Gfx_EnableClear(void)

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -121,14 +121,14 @@ static GLuint generic_shader_id;
 #define TPAGE_X 16
 #define TPAGE_Y 2
 
-GLuint plain_texture;
-GLuint tpage_texture[TPAGE_Y * TPAGE_X];
+static GLuint plain_texture;
+static GLuint tpage_texture[TPAGE_Y * TPAGE_X];
 
 //Batch
-GLuint batch_vao;
-GLuint batch_vbo;
+static GLuint batch_vao;
+static GLuint batch_vbo;
 
-GLuint batch_texture_id;
+static GLuint batch_texture_id;
 
 static Gfx_Vertex batch_buffer[COUNT_OF(dlist)][6]; //TODO: index buffer
 static Gfx_Vertex *batch_buffer_p;

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -337,7 +337,7 @@ void Gfx_Init(void)
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
 #endif
 	glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
-	glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
+	glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
 	
 	//Get monitor video mode
 	GLFWmonitor *monitor = glfwGetPrimaryMonitor();
@@ -475,10 +475,24 @@ void Gfx_Flip(void)
 	if (glfwWindowShouldClose(window))
 		exit(0);
 	
-	//Update render state
+	//Update the viewport in case the window has been resized
 	int fb_width, fb_height;
 	glfwGetFramebufferSize(window, &fb_width, &fb_height);
-	glViewport(0, 0, fb_width, fb_height);
+
+	// Center the viewport within the window while maintaining the aspect ratio
+	GLfloat viewport_width, viewport_height;
+	if ((float)fb_width / (float)fb_height > (float)SCREEN_WIDTH / (float)SCREEN_HEIGHT)
+	{
+		viewport_width = fb_height * SCREEN_WIDTH / SCREEN_HEIGHT;
+		viewport_height = fb_height;
+	}
+	else
+	{
+		viewport_width = fb_width;
+		viewport_height = fb_width * SCREEN_HEIGHT / SCREEN_WIDTH;
+	}
+
+	glViewport((fb_width - viewport_width) / 2, (fb_height - viewport_height) / 2, viewport_width, viewport_height);
 	
 	//Initialize frame
 	dlist_p = dlist;

--- a/src/pc/gfx.c
+++ b/src/pc/gfx.c
@@ -752,12 +752,15 @@ void Gfx_LoadTex(Gfx_Tex *tex, IO_Data data, Gfx_LoadTex_Flag flag)
 		}
 		case 2: //16bpp
 		{
+			sprintf(error_msg, "[Gfx_LoadTex] 16bpp unsupported");
+			ErrorLock(); //Doesn't actuall return
 			break;
 		}
 		case 3: //24bpp
 		{
 			sprintf(error_msg, "[Gfx_LoadTex] 24bpp unsupported");
-			ErrorLock();
+			ErrorLock(); //Doesn't actuall return
+			break;
 		}
 	}
 	

--- a/src/random.c
+++ b/src/random.c
@@ -8,23 +8,23 @@ void RandomSeed(u32 seed)
 	rand_seed = seed;
 }
 
-u32 RandomGetSeed()
+u32 RandomGetSeed(void)
 {
 	return rand_seed;
 }
 
-u8 Random8()
+u8 Random8(void)
 {
 	return Random16() >> 4;
 }
 
-u16 Random16()
+u16 Random16(void)
 {
 	rand_seed = rand_seed * 214013L + 2531011L;
 	return rand_seed >> 16;
 }
 
-u32 Random32()
+u32 Random32(void)
 {
 	return ((u32)Random16() << 16) | Random16();
 }

--- a/src/stage.c
+++ b/src/stage.c
@@ -49,7 +49,7 @@ static const StageDef stage_defs[StageId_Max] = {
 Stage stage;
 
 //Stage music functions
-void Stage_StartVocal()
+void Stage_StartVocal(void)
 {
 	if (!(stage.flag & STAGE_FLAG_VOCAL_ACTIVE))
 	{
@@ -58,7 +58,7 @@ void Stage_StartVocal()
 	}
 }
 
-void Stage_CutVocal()
+void Stage_CutVocal(void)
 {
 	if (stage.flag & STAGE_FLAG_VOCAL_ACTIVE)
 	{
@@ -77,7 +77,7 @@ void Stage_FocusCharacter(Character *ch, fixed_t div)
 	stage.camera.td = div;
 }
 #include "mutil.h"
-void Stage_ScrollCamera()
+void Stage_ScrollCamera(void)
 {
 	#ifdef STAGE_FREECAM
 		if (pad_state.held & PAD_LEFT)
@@ -559,7 +559,7 @@ void Stage_DrawHealth(u8 i, s8 ox)
 	Stage_DrawTex(&stage.tex_hud1, &src, &dst, FIXED_MUL(stage.bump, stage.sbump));
 }
 
-void Stage_DrawNotes()
+void Stage_DrawNotes(void)
 {
 	//Initialize scroll state
 	SectionScroll scroll;
@@ -1008,7 +1008,7 @@ void Stage_Load(StageId id, StageDiff difficulty, boolean story)
 	stage.offset = 0;
 }
 
-void Stage_Unload()
+void Stage_Unload(void)
 {
 	//Unload stage background
 	if (stage.back != NULL)
@@ -1032,7 +1032,7 @@ void Stage_Unload()
 	stage.gf = NULL;
 }
 
-void Stage_NextLoad()
+void Stage_NextLoad(void)
 {
 	u8 load = stage.stage_def->next_load;
 	if (load == 0)
@@ -1093,7 +1093,7 @@ void Stage_NextLoad()
 	}
 }
 
-void Stage_Tick()
+void Stage_Tick(void)
 {
 	SeamLoad:;
 	

--- a/src/stage/dummy.c
+++ b/src/stage/dummy.c
@@ -18,7 +18,7 @@ void Back_Dummy_Free(StageBack *back)
 	Mem_Free(this);
 }
 
-StageBack *Back_Dummy_New()
+StageBack *Back_Dummy_New(void)
 {
 	//Allocate background structure
 	Back_Dummy *this = (Back_Dummy*)Mem_Alloc(sizeof(Back_Dummy));

--- a/src/stage/week1.c
+++ b/src/stage/week1.c
@@ -89,7 +89,7 @@ void Back_Week1_Free(StageBack *back)
 	Mem_Free(this);
 }
 
-StageBack *Back_Week1_New()
+StageBack *Back_Week1_New(void)
 {
 	//Allocate background structure
 	Back_Week1 *this = (Back_Week1*)Mem_Alloc(sizeof(Back_Week1));

--- a/src/stage/week2.c
+++ b/src/stage/week2.c
@@ -66,7 +66,7 @@ void Back_Week2_Free(StageBack *back)
 	Mem_Free(this);
 }
 
-StageBack *Back_Week2_New()
+StageBack *Back_Week2_New(void)
 {
 	//Allocate background structure
 	Back_Week2 *this = (Back_Week2*)Mem_Alloc(sizeof(Back_Week2));

--- a/src/stage/week3.c
+++ b/src/stage/week3.c
@@ -229,7 +229,7 @@ void Back_Week3_Free(StageBack *back)
 	Mem_Free(this);
 }
 
-StageBack *Back_Week3_New()
+StageBack *Back_Week3_New(void)
 {
 	//Allocate background structure
 	Back_Week3 *this = (Back_Week3*)Mem_Alloc(sizeof(Back_Week3));

--- a/src/stage/week4.c
+++ b/src/stage/week4.c
@@ -213,7 +213,7 @@ void Back_Week4_Free(StageBack *back)
 	Mem_Free(this);
 }
 
-StageBack *Back_Week4_New()
+StageBack *Back_Week4_New(void)
 {
 	//Allocate background structure
 	Back_Week4 *this = (Back_Week4*)Mem_Alloc(sizeof(Back_Week4));

--- a/src/stage/week7.c
+++ b/src/stage/week7.c
@@ -207,7 +207,7 @@ void Back_Week7_Free(StageBack *back)
 	Mem_Free(this);
 }
 
-StageBack *Back_Week7_New()
+StageBack *Back_Week7_New(void)
 {
 	//Allocate background structure
 	Back_Week7 *this = (Back_Week7*)Mem_Alloc(sizeof(Back_Week7));


### PR DESCRIPTION
If `plain_texture` were merged with `vram_texture`, then an entire frame could be batched...