### PR TITLE
Re-fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ iso/*/*.tim
 iso/*/*.arc
 iso/*/*.xa
 iso/*/*.cht
+
+# Big Chungus


### PR DESCRIPTION
PR #30 was effectively reverted (in all likelihood by accident) in 8cab0c1afeccabfb600947a4eade7eb667c216c0. This PR re-adds the change to .gitignore.